### PR TITLE
Fix git dirty tracking for different git versions

### DIFF
--- a/src/arachne/buildtools/git.clj
+++ b/src/arachne/buildtools/git.clj
@@ -10,8 +10,8 @@
   "Throw an exception if the git project at the given directory is not clean."
   [git-dir msg]
   (let [f (.getAbsoluteFile (io/file git-dir))
-        status (:out (sh/sh "git" "status" :dir git-dir))]
-    (when-not (re-find #"nothing to commit, working directory clean" status)
+        status (:out (sh/sh "git" "status" "--porcelain" :dir git-dir))]
+    (when-not (s/blank? status)
       (throw (ex-info msg {:git-dir git-dir, :file f})))))
 
 (defn current-sha


### PR DESCRIPTION
On my machine, the `git status` string being matched is different from
the actual "clean slate" message (my git version: 2.9.2).

Going further, I've found that using `git status` output for this kind
of "scripting" is not really supported, since status is what is called [a
"porcelain" command](https://git-scm.com/book/tr/v2/Git-Internals-Plumbing-and-Porcelain).

Following [this SO answer](https://stackoverflow.com/a/2659808), this commit make use of an alternative
"plumbing" command to do the dirty tracking - so far, it worked pretty
well.
