### PR TITLE
Fix local dependencies

### DIFF
--- a/project.edn
+++ b/project.edn
@@ -1,5 +1,5 @@
 {:project org.arachne-framework/arachne-buildtools
- :version {:major 0, :minor 1, :patch 2}
+ :version {:major 0, :minor 1, :patch 3, :qualifier :dev}
  :description "Build tools for managing and building Arachne's core modules"
  :license {"Apache Software License 2.0" "http://www.apache.org/licenses/LICENSE-2.0"}
  :deps [[boot/core "2.6.0" :scope "test"]


### PR DESCRIPTION
Keep the JAR file of a local dep on the classpath, even when it has
local source dirs specified.

This is necessary to read files that are expected to exist multiple
times on the classpath, since boot merges all the source files into a
single fileset.
