### PR TITLE
Enable the multi-line flag for the revision regex

### DIFF
--- a/src/arachne/buildtools/git.clj
+++ b/src/arachne/buildtools/git.clj
@@ -84,4 +84,4 @@
       (exec! "git" "clone" repo clone-dir))
     (exec! "git" "checkout" ref :dir clone-dir)
     (let [result (exec! "boot" "build" :dir clone-dir)]
-      (second (re-find #"Installed Version:\s*(.*)$" (:out result))))))
+      (second (re-find #"(?m)^Installed Version:\s*(.*)$" (:out result))))))


### PR DESCRIPTION
The output of `boot build` is a multi-line string, so to parse out the installed
artifact version we need to use a the multi-line regex flag.

I also anchor the regex to the beginning of the line with `^`

I was playing with git-based dependencies and the regex in [git.clj](https://github.com/arachne-framework/arachne-buildtools/blob/master/src/arachne/buildtools/git.clj#L87) wasn't matching the output.